### PR TITLE
AppId - Fixed androidId in the PhoneID function

### DIFF
--- a/AppId/Droid/AppId.Droid.csproj
+++ b/AppId/Droid/AppId.Droid.csproj
@@ -38,6 +38,10 @@
     <Reference Include="Cirrious.CrossCore">
       <HintPath>..\..\submodules\MvvmCross-Binaries\VS2012\bin\Debug\Mvx\Portable\Cirrious.CrossCore.dll</HintPath>
     </Reference>
+    <Reference Include="Cirrious.CrossCore.Droid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\submodules\MvvmCross-Binaries\VS2012\bin\Debug\Mvx\Droid\Cirrious.CrossCore.Droid.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/AppId/Droid/AppIdGenerator.cs
+++ b/AppId/Droid/AppIdGenerator.cs
@@ -17,6 +17,8 @@
 using System;
 using Android.OS;
 using Android.Provider;
+using Cirrious.CrossCore;
+using Cirrious.CrossCore.Droid;
 
 namespace Cheesebaron.MvxPlugins.AppId
 {
@@ -55,8 +57,10 @@ namespace Cheesebaron.MvxPlugins.AppId
                 var androidId = "";
                 try
                 {
-                    // Not 100% reliable on 2.2 (API 8)
-                    androidId = Settings.Secure.AndroidId;
+                    // Not 100% reliable on 2.2 (API 8)'
+                    var globals = Mvx.Resolve<IMvxAndroidGlobals>();
+                    androidId = Settings.Secure.GetString(globals.ApplicationContext.ContentResolver, Settings.Secure.AndroidId);
+
                 }
                 catch(Exception) {}
 


### PR DESCRIPTION
The current way of getting the androidId does not actually do anything. This should fix it.

Signed-off-by: Ryan Schlesinger noxryan@gmail.com
