### PR TITLE
execute connectivity check in ctor

### DIFF
--- a/Connectivity/Droid/Connectivity.cs
+++ b/Connectivity/Droid/Connectivity.cs
@@ -33,12 +33,11 @@ namespace Cheesebaron.MvxPlugins.Connectivity.Droid
         {
             ConnectivityChangeBroadcastReceiver.OnChange = info => NetworkChanged(info);
 
-            Mvx.CallbackWhenRegistered<IMvxAndroidGlobals>(x => {
-                var manager =
-                    x.ApplicationContext.GetSystemService(Context.ConnectivityService)
+            var globals = Mvx.Resolve<IMvxAndroidGlobals>();
+            var manager =
+                    globals.ApplicationContext.GetSystemService(Context.ConnectivityService)
                         .JavaCast<ConnectivityManager>();
-                NetworkChanged(manager.ActiveNetworkInfo, false);
-            });
+            NetworkChanged(manager.ActiveNetworkInfo, false);
         }
 
         private void NetworkChanged(NetworkInfo info, bool fireMissiles = true)


### PR DESCRIPTION
This should prevent that the network information are not properly
initialized.

fix #61