### PR TITLE
Fix null activenetworkinfo not handled

### DIFF
--- a/Connectivity/Droid/Connectivity.cs
+++ b/Connectivity/Droid/Connectivity.cs
@@ -42,7 +42,11 @@ namespace Cheesebaron.MvxPlugins.Connectivity.Droid
 
         private void NetworkChanged(NetworkInfo info, bool fireMissiles = true)
         {
-            if (info == null) return;
+            if (info == null) // null when airplane mode
+            {
+                ChangeConnectivityStatus(false, false, false, fireMissiles);
+                return;
+            }
 
             ChangeConnectivityStatus(info.IsConnected, info.Type == ConnectivityType.Wifi,
                 info.Type == ConnectivityType.Mobile, fireMissiles);

--- a/Samples/Connectivity/Core/ViewModels/WifiViewModel.cs
+++ b/Samples/Connectivity/Core/ViewModels/WifiViewModel.cs
@@ -25,7 +25,7 @@ namespace Core.ViewModels
         public string IpAddress => _info.Extra?.IpAddress;
         public string MacAddress => _info.Extra?.MacAddress;
         public string SecurityMode => _info.Extra?.SecurityMode;
-        public int? Rssi => _info.Extra?.Rssi;
+        public int? Rssi => (int?) _info.Extra?.Rssi;
     }
 
 


### PR DESCRIPTION
Hopefully this fixes #71 

At least this revealed that `ActiveNetworkInfo` when asking the `ConnectivityManager` on Android, it becomes null when airplane mode is on.

Otherwise it seems like the `BroadcastReceiver` is triggered correctly when toggling airplane mode on and off, the same goes for toggling wifi and cellular.