### PR TITLE
Don't throw exception when configuration is null

### DIFF
--- a/Settings/platforms/android/Plugin.cs
+++ b/Settings/platforms/android/Plugin.cs
@@ -25,6 +25,9 @@ namespace Cheesebaron.MvxPlugins.Settings
 
         public void Configure(IMvxPluginConfiguration configuration)
         {
+            if (configuration == null)
+                return;
+
             if (!(configuration is DroidCheeseSettingsConfiguration cheeseSettingsConfiguration))
                 throw new MvxException(
                     "Plugin configuration only supports instances of DroidCheeseSettingsConfiguration, you provided {0}",

--- a/Settings/platforms/wpf/Plugin.cs
+++ b/Settings/platforms/wpf/Plugin.cs
@@ -30,6 +30,9 @@ namespace Cheesebaron.MvxPlugins.Settings
 
         public void Configure(IMvxPluginConfiguration configuration)
         {
+            if (configuration == null)
+                return;
+
             if (!(configuration is WpfCheeseSettingsConfiguration cheeseSettingsConfiguration))
                 throw new MvxException(
                     "Plugin configuration only supports instances of WpfCheeseSettingsConfiguration, you provided {0}",


### PR DESCRIPTION
When configuration is null (default scenario) the plugin throws an exception and makes Apps get stuck at splash.

Now the code just returns in case of null.

Fixes #111